### PR TITLE
Add Remember Me feature and fix circle drag detection

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1434,12 +1434,18 @@ const CompletePRSApp = () => {
                               }
                             }
 
-                            // Check if clicking inside circle (for dragging)
+                            // Check if clicking NEAR the circle perimeter (for dragging)
+                            // Only detect drag on the outline/stroke, NOT in the center
                             const distFromCenter = Math.sqrt(
                               Math.pow(imageX - currentX, 2) + Math.pow(imageY - currentY, 2)
                             );
 
-                            if (distFromCenter <= currentRadius * 0.8) {
+                            // Calculate distance from the perimeter (how far from the outline)
+                            const distFromPerimeter = Math.abs(distFromCenter - currentRadius);
+                            const dragThreshold = 25; // pixels - allow drag within 25px of the outline (good for mobile)
+
+                            if (distFromPerimeter <= dragThreshold) {
+                              // Clicking near the perimeter - allow drag
                               setIsDragging(true);
                               setDragTargetId(target.id);
                               setDragStart({ x: imageX - currentX, y: imageY - currentY });
@@ -1447,6 +1453,7 @@ const CompletePRSApp = () => {
                               e.stopPropagation();
                               return;
                             }
+                            // If clicking in center (far from perimeter), allow click to pass through for shot marking
                           }}
                           onMouseMove={(e) => {
                             if (!isDragging && !isResizing) return;

--- a/src/components/Auth.js
+++ b/src/components/Auth.js
@@ -2,7 +2,10 @@ import React, { useState } from 'react';
 import {
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
-  signOut
+  signOut,
+  setPersistence,
+  browserLocalPersistence,
+  browserSessionPersistence
 } from 'firebase/auth';
 import { auth } from '../firebase';
 import { LogIn, LogOut, UserPlus, Mail, Lock, User, AlertCircle } from 'lucide-react';
@@ -13,6 +16,7 @@ const Auth = ({ user, onAuthStateChange }) => {
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [displayName, setDisplayName] = useState('');
+  const [rememberMe, setRememberMe] = useState(true);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -22,7 +26,12 @@ const Auth = ({ user, onAuthStateChange }) => {
     setLoading(true);
 
     try {
+      // Set persistence before login
       if (isLogin) {
+        await setPersistence(
+          auth,
+          rememberMe ? browserLocalPersistence : browserSessionPersistence
+        );
         // Login
         await signInWithEmailAndPassword(auth, email, password);
       } else {
@@ -37,6 +46,10 @@ const Auth = ({ user, onAuthStateChange }) => {
           setLoading(false);
           return;
         }
+        await setPersistence(
+          auth,
+          rememberMe ? browserLocalPersistence : browserSessionPersistence
+        );
         await createUserWithEmailAndPassword(auth, email, password);
       }
 
@@ -179,6 +192,20 @@ const Auth = ({ user, onAuthStateChange }) => {
               </div>
             </div>
           )}
+
+          {/* Remember Me Checkbox */}
+          <div className="flex items-center">
+            <input
+              id="remember-me"
+              type="checkbox"
+              checked={rememberMe}
+              onChange={(e) => setRememberMe(e.target.checked)}
+              className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 dark:border-gray-600 rounded"
+            />
+            <label htmlFor="remember-me" className="ml-2 block text-sm text-gray-700 dark:text-gray-300">
+              Remember me (stay signed in)
+            </label>
+          </div>
 
           <button
             type="submit"


### PR DESCRIPTION
- Add "Remember Me" checkbox with Firebase persistence control
- Users can choose between session and local persistence
- Fix circle drag to only detect clicks near perimeter (within 25px)
- Center area now allows shot marking without triggering drag
- Improves mobile usability with better touch target distinction