### PR TITLE
Fix target adjustment UX and improve training data collection

### DIFF
--- a/src/services/firestore.js
+++ b/src/services/firestore.js
@@ -337,6 +337,12 @@ export const addTrainingImage = async (imageBlob, metadata) => {
       storagePath: `training-images/${trainingId}.jpg`,
       shots: metadata.shots || 0,
       targetDiameter: metadata.diameter || 0,
+      // Target center coordinates for training target detection
+      centerX: metadata.centerX || 0,
+      centerY: metadata.centerY || 0,
+      radius: metadata.radius || 0,
+      imageWidth: metadata.imageWidth || 0,
+      imageHeight: metadata.imageHeight || 0,
       timestamp: serverTimestamp(),
       version: 1 // For future schema changes
     });


### PR DESCRIPTION
Changes:
- Add target center coordinates to training data (centerX, centerY, radius, imageWidth, imageHeight) to improve OpenCV target detection training
- Remove resize handles from mark-shots step - circle is now static reference only
- Fix resize handle hit detection in adjust-targets to match rendered positions (using diagonal angles instead of cardinal positions)
- Make mark-shots target circle non-interactive (pointer-events: none)

This addresses user feedback:
- Training data now captures WHERE user placed target center (not just bullet holes)
- Mark-shots step no longer shows adjustable target (as requested)
- Desktop resize now works in adjust-targets step (handles are clickable)