### PR TITLE
Fix adjust-targets grey screen: Replace broken img with SVG image ele…

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1686,9 +1686,12 @@ const CompletePRSApp = () => {
                     const currentX = target.adjustedX ?? target.x;
                     const currentY = target.adjustedY ?? target.y;
                     const currentRadius = target.adjustedRadius || target.radius;
-                    const cropSize = currentRadius * 10;
-                    const cropX = currentX - currentRadius * 5;
-                    const cropY = currentY - currentRadius * 5;
+
+                    // Use fixed crop region based on initial radius (stable viewBox)
+                    const initialRadius = target.radius;
+                    const cropSize = initialRadius * 10; // Fixed size
+                    const cropX = currentX - cropSize / 2; // Center on target
+                    const cropY = currentY - cropSize / 2;
 
                     return (
                       <div key={target.id} className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4">
@@ -1787,8 +1790,8 @@ const CompletePRSApp = () => {
                               href={uploadedImage}
                               x={-cropX}
                               y={-cropY}
-                              width="100%"
-                              height="100%"
+                              width={target.imageWidth}
+                              height={target.imageHeight}
                               preserveAspectRatio="none"
                             />
 


### PR DESCRIPTION
…ment

Fixed critical rendering bugs in adjust-targets step:

Issues Fixed:
- Slider was moving image around arbitrary point (viewBox size was changing)
- Image was stretching/not scaling properly (used 100% width/height)
- Green circle appeared to get thicker (stroke was scaling with viewBox)
- Center was not properly centered on target

Root Cause:
- cropSize, cropX, cropY were all based on currentRadius (changing value)
- When slider changed radius, viewBox size changed, causing:
  - Image to stretch to fill new viewBox size
  - All coordinates to shift
  - Everything to look broken

Solution:
- Use FIXED viewBox based on initialRadius (stable)
- Center crop region properly: cropX = currentX - cropSize/2
- Use actual image dimensions: width={target.imageWidth} height={target.imageHeight}
- Now ONLY the circle radius changes, everything else stays stable

Result:
- Slider now smoothly changes target size without moving image
- Image displays at correct scale
- Circle stays centered
- No more weird stretching or shifting