### PR TITLE
Fix slider range and prevent click-through on release

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1839,15 +1839,20 @@ const CompletePRSApp = () => {
                           </svg>
 
                           {/* Vertical size slider - overlay on left side of image */}
-                          <div className="absolute left-2 top-1/2 -translate-y-1/2 flex flex-col items-center gap-2 pointer-events-auto" style={{ zIndex: 10 }}>
+                          <div
+                            className="absolute left-2 top-1/2 -translate-y-1/2 flex flex-col items-center gap-2 pointer-events-auto"
+                            style={{ zIndex: 10 }}
+                            onClick={(e) => e.stopPropagation()}
+                            onMouseDown={(e) => e.stopPropagation()}
+                          >
                             <div className="bg-gray-100/90 dark:bg-gray-700/90 rounded-lg px-2 py-1 text-xs font-medium text-gray-900 dark:text-white shadow-lg">
                               {target.diameterInches}"
                             </div>
                             <input
                               type="range"
                               orient="vertical"
-                              min={Math.max(10, target.radius * 0.5)}
-                              max={target.radius * 2}
+                              min={Math.max(10, target.radius * 0.3)}
+                              max={target.radius * 5}
                               value={currentRadius}
                               onChange={(e) => {
                                 const newRadius = parseFloat(e.target.value);
@@ -1858,6 +1863,8 @@ const CompletePRSApp = () => {
                                     : t
                                 ));
                               }}
+                              onClick={(e) => e.stopPropagation()}
+                              onMouseDown={(e) => e.stopPropagation()}
                               className="h-48 appearance-none bg-gray-200 dark:bg-gray-700 rounded-lg cursor-pointer accent-lime-500"
                               style={{
                                 writingMode: 'bt-lr',


### PR DESCRIPTION
Slider Range Fix:
- Increased max from 2x to 5x initial radius (can go much larger now)
- Decreased min from 0.5x to 0.3x initial radius (can go smaller too)
- Range: 30% to 500% of initial target size
- Allows for very zoomed-in or very wide shots

Click-Through Fix:
- Added stopPropagation() to slider container div
- Added stopPropagation() to slider input (onClick and onMouseDown)
- Prevents parent's click-to-center handler from firing
- User can now release slider without moving target center

Before:
- Range limited to 0.5x - 2x (too restrictive)
- Releasing slider moved target center (annoying!)

After:
- Range 0.3x - 5x (much more flexible)
- Slider interactions don't affect target position